### PR TITLE
Update args parsing in DbtItem._get_adapter

### DIFF
--- a/pytest_dbt_adapter/spec_file.py
+++ b/pytest_dbt_adapter/spec_file.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 import json
 import os
 import random
@@ -17,7 +18,8 @@ from .builtin import BUILTIN_TEST_SEQUENCES, DEFAULT_PROJECTS, DbtProject
 
 from dbt.adapters.factory import FACTORY
 from dbt.config import RuntimeConfig
-from dbt.main import parse_args
+from dbt.flags import set_from_args
+from dbt.cli.main import compile
 
 
 class DbtSpecFile(pytest.File):
@@ -104,11 +106,15 @@ class DbtItem(pytest.Item):
 
     def _get_adapter(self, tmpdir):
         project_path = os.path.join(tmpdir, 'project')
-        args = parse_args([
-            'compile', '--profile', 'dbt-pytest', '--target', 'default',
+
+        # make a dummy context to get the parameters
+        ctx = compile.make_context("compile", [
+            '--profile', 'dbt-pytest', '--target', 'default',
             '--project-dir', project_path, '--profiles-dir', tmpdir,
             '--vars', yaml.safe_dump(self._base_vars()),
         ])
+        args = Namespace(**ctx.params)
+
         with open(os.path.join(args.profiles_dir, 'profiles.yml')) as fp:
             data = yaml.safe_load(fp)
             try:
@@ -130,6 +136,10 @@ class DbtItem(pytest.Item):
             except KeyError:
                 raise ValueError(
                     f'target {args.target} in {args.profile} has no type')
+
+        # initialize the global flags
+        set_from_args(args, None)
+
         _ = FACTORY.load_plugin(adapter_type)
         config = RuntimeConfig.from_args(args)
 
@@ -359,7 +369,7 @@ class DbtItem(pytest.Item):
                         try:
                             value = self._get_from_dict(result, key.split('.'))
                             if value != expected_value:
-                                raise DBTException (
+                                raise DBTException(
                                     f'Expected attribute value \'{expected_value}\' but got \'{value}\' for attribute \'{key}\''
                                 ) from None
                         except KeyError as exc:
@@ -615,7 +625,7 @@ class DbtItem(pytest.Item):
             raise TestProcessingException(
                 f'Could not find type in {test_item}'
             ) from None
-        print(f'Executing step {idx+1}/{len(self.sequence)}')
+        print(f'Executing step {idx + 1}/{len(self.sequence)}')
         try:
             if item_type == 'dbt':
                 assert os.path.exists(tmpdir)


### PR DESCRIPTION
dbt is now implemented using click.
parse_args function from dbt.main has been removed.
This patch adjusts the code to enable tests to run again using dbt-core==1.6.2  